### PR TITLE
Enum support

### DIFF
--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -40,6 +40,7 @@ final class Types
             is_int($value) => self::NUMBER,
             is_float($value) => self::NUMBER,
             is_array($value) => $this->processArray($value),
+            $value instanceof \BackedEnum => $this->processEnum($value),
             $value instanceof ResourceCollection => TypescriptType::determineName($value->collects).'[]',
             $value instanceof JsonResource => TypescriptType::determineName(get_class($value)),
             $value instanceof Arrayable => $this->processArray($value->toArray()), // TODO: Test for this
@@ -61,5 +62,10 @@ final class Types
         $types = collect($value)->map(fn ($value) => $this->determineType($value))->unique();
 
         return $types->join('|').'[]';
+    }
+
+    private function processEnum(\BackedEnum $value)
+    {
+        return join(' | ', Arr::map(array_column($value::cases(), 'value'), fn ($val) => is_string($val) ? "'$val'" : $val));
     }
 }

--- a/tests/Fakes/Enums/TestEnum.php
+++ b/tests/Fakes/Enums/TestEnum.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Vagebond\Runtype\Tests\Fakes\Enums;
+
+enum TestEnum: string
+{
+    case VALUE_1 = 'enum-value-1';
+    case VALUE_2 = 'enum-value-2';
+}

--- a/tests/Types/TypesTest.php
+++ b/tests/Types/TypesTest.php
@@ -19,5 +19,5 @@ it('can determine a type from a value', function ($value, $expected) {
     [['name' => 'name', 'value' => 1], '{name:string,value:number}'],
     [['name' => 'name', 'values' => ['name' => 'value']], '{name:string,values:{name:string}}'],
     [(object) ['name' => 'name', 'value' => 1], '{name:string,value:number}'],
-    [TestEnum::VALUE_1, 'enum-value-1 | enum-value-2'],
+    [TestEnum::VALUE_1, '\'enum-value-1\' | \'enum-value-2\''],
 ]);

--- a/tests/Types/TypesTest.php
+++ b/tests/Types/TypesTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Vagebond\Runtype\Tests\Fakes\Enums\TestEnum;
 use Vagebond\Runtype\Tests\Fakes\Models\Product;
 use Vagebond\Runtype\Tests\Fakes\Resources\ProductResource;
 use Vagebond\Runtype\Types\Types;
@@ -18,4 +19,5 @@ it('can determine a type from a value', function ($value, $expected) {
     [['name' => 'name', 'value' => 1], '{name:string,value:number}'],
     [['name' => 'name', 'values' => ['name' => 'value']], '{name:string,values:{name:string}}'],
     [(object) ['name' => 'name', 'value' => 1], '{name:string,value:number}'],
+    [TestEnum::VALUE_1, 'enum-value-1 | enum-value-2'],
 ]);


### PR DESCRIPTION
This pull request enhances enum type handling in the `Types` class to improve how PHP enums are converted for TypeScript type generation. The most important changes are the addition of support for `BackedEnum` instances and a new method for processing enums.

**Enum type handling improvements:**

* Updated the `determineType` method in `src/Types/Types.php` to handle values that are instances of `\BackedEnum`, delegating their processing to the new `processEnum` method.
* Added a new private method `processEnum` in `src/Types/Types.php` that generates a TypeScript union type string from all possible enum values, properly quoting string values.