### PR TITLE
feat: group php namespace to ts namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Generate TypeScript interfaces from Laravel Models & Resources
 
 This resource:
 ```PHP
+
+namespace App\Http\Resources;
+
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /** @mixin \App\Models\Product */
@@ -30,10 +33,12 @@ class ProductResource extends JsonResource
 will be converted into this interface:
 
 ```typescript
-export interface ProductResourceType {
+declare namespace App.Http.Resources {
+  export interface ProductResourceType {
     id: number;
     name: string;
     hidden?: boolean;
+  }
 }
 ```
 

--- a/src/Actions/TranspileToTypescript.php
+++ b/src/Actions/TranspileToTypescript.php
@@ -19,30 +19,45 @@ class TranspileToTypescript
     /** @param  Collection<TypescriptType>  $types */
     public function handle(Collection $types)
     {
-        $types->each(fn (TypescriptType $type) => $this->processType($type));
+        $lines = $this->lines;
+
+        $this->groupTypes($types)->each(function (Collection $groupedTypes, string $group) use (&$lines) {
+            $lines->push("declare namespace {$group} {");
+            $groupedTypes->each(fn (TypescriptType $type) => $this->processType($type));
+            $lines->push('}'.PHP_EOL);
+        });
 
         return $this->lines->join(PHP_EOL);
     }
 
+    /**
+     * @param  Collection<TypescriptType>  $types
+     * @return Collection<string, Collection<int, TypescriptType>>
+     */
+    private function groupTypes(Collection $types): Collection
+    {
+        return $types->mapToGroups(function (TypescriptType $type) {
+            return [TypescriptType::determineNamespace($type->getClass()) => $type];
+        });
+    }
+
     private function processType(TypescriptType $type): void
     {
-        $this->lines->push("// {$type->getClass()}");
-
         if ($type->listProperties()->isEmpty()) {
-            $this->lines->push("export type {$type->getName()} = any");
+            $this->lines->push("\texport type {$type->getName()} = any");
 
             return;
         }
 
-        $this->lines->push("export type {$type->getName()} = {");
+        $this->lines->push("\texport type {$type->getName()} = {");
 
         $type->listProperties()->each(fn (TypescriptProperty $property) => $this->processProperty($property));
 
-        $this->lines->push('}');
+        $this->lines->push("\t}");
     }
 
     private function processProperty(TypescriptProperty $property): void
     {
-        $this->lines->push("{$property->getName()}:{$property->getType()}");
+        $this->lines->push("\t\t{$property->getName()}: {$property->getType()};");
     }
 }

--- a/src/Types/Types.php
+++ b/src/Types/Types.php
@@ -41,8 +41,8 @@ final class Types
             is_float($value) => self::NUMBER,
             is_array($value) => $this->processArray($value),
             $value instanceof \BackedEnum => $this->processEnum($value),
-            $value instanceof ResourceCollection => TypescriptType::determineName($value->collects).'[]',
-            $value instanceof JsonResource => TypescriptType::determineName(get_class($value)),
+            $value instanceof ResourceCollection => TypescriptType::determineNamespace($value->collects).'.'.TypescriptType::determineName($value->collects).'[]',
+            $value instanceof JsonResource => TypescriptType::determineNamespace(get_class($value)).'.'.TypescriptType::determineName(get_class($value)),
             $value instanceof Arrayable => $this->processArray($value->toArray()), // TODO: Test for this
             is_object($value) => $this->processArray((array) $value),
             default => self::UNKNOWN,

--- a/src/Values/TypescriptType.php
+++ b/src/Values/TypescriptType.php
@@ -60,9 +60,17 @@ class TypescriptType
         return $this;
     }
 
-    public static function determineName(string $class): string
+    public static function determineNamespace(string $className): string
     {
-        $class = new ReflectionClass($class);
+        $namespace = explode('\\', $className);
+        array_pop($namespace);
+
+        return implode('.', $namespace);
+    }
+
+    public static function determineName(string $className): string
+    {
+        $class = new ReflectionClass($className);
 
         return $class->getShortName().'Type';
     }

--- a/tests/Actions/TranspileToTypescriptTest.php
+++ b/tests/Actions/TranspileToTypescriptTest.php
@@ -21,11 +21,11 @@ it('can transpile to typescript', function () {
     $generated = (new TranspileToTypescript)->handle(collect([$type]));
     $lines = explode(PHP_EOL, $generated);
 
-    expect($lines)->toContain('export type ProductResourceType = {');
-    expect($lines)->toContain('}');
+    expect($lines)->toContain("\texport type ProductResourceType = {");
+    expect($lines)->toContain("\t}");
 
     $type->listProperties()->each(function (TypescriptProperty $property) use ($lines) {
-        expect($lines)->toContain("{$property->getName()}:{$property->getType()}");
+        expect($lines)->toContain("\t\t{$property->getName()}: {$property->getType()};");
     });
 });
 
@@ -35,5 +35,5 @@ it('can handle types with no properties', function () {
     $generated = (new TranspileToTypescript)->handle(collect([$type]));
     $lines = explode(PHP_EOL, $generated);
 
-    expect($lines)->toContain('export type ProductResourceType = any');
+    expect($lines)->toContain("\texport type ProductResourceType = any");
 });

--- a/tests/Converters/ResourceConverterTest.php
+++ b/tests/Converters/ResourceConverterTest.php
@@ -38,7 +38,7 @@ it('can convert resource collections', function () {
     $property = $processed->listProperties()->first();
 
     expect($property->getName())->toBe('data');
-    expect($property->getType())->toBe('ProductResourceType[]');
+    expect($property->getType())->toBe('Vagebond.Runtype.Tests.Fakes.Resources.ProductResourceType[]');
 });
 
 it('can convert resources that use the user bound to the request', function () {

--- a/tests/Types/TypesTest.php
+++ b/tests/Types/TypesTest.php
@@ -14,7 +14,7 @@ it('can determine a type from a value', function ($value, $expected) {
     [-1, 'number'],
     [1.1, 'number'],
     [now(), 'string'],
-    [new ProductResource(new Product), 'ProductResourceType'],
+    [new ProductResource(new Product), 'Vagebond.Runtype.Tests.Fakes.Resources.ProductResourceType'],
     [[1, 2, 3], 'number[]'],
     [['name' => 'name', 'value' => 1], '{name:string,value:number}'],
     [['name' => 'name', 'values' => ['name' => 'value']], '{name:string,values:{name:string}}'],


### PR DESCRIPTION
This pull request introduces a significant improvement to the TypeScript interface generation process from Laravel models and resources. The main change is the addition of namespace grouping, so all generated TypeScript types are now wrapped in appropriate `declare namespace` blocks based on their PHP namespaces. This ensures clearer organization, prevents naming collisions, and improves type references. The pull request also updates formatting and test expectations to reflect these changes.

**Feature request**
This PR is the followup based on the feature request: https://github.com/vagebnd/runtype/issues/14

**Namespace Grouping & Type Reference Improvements:**

* Typescript types are now grouped and wrapped in `declare namespace` blocks, determined by their PHP class namespaces, both in the generator and in the expected output.
* Type references for Laravel resources now include the namespace, e.g., `Vagebond.Runtype.Tests.Fakes.Resources.ProductResourceType`, instead of just `ProductResourceType`.

**Formatting Enhancements:**

* Types and properties are indented within the namespace block for improved readability and consistency. 
* Test expectations updated to match the new formatting and namespace usage.

**Upcoming Enhancements:**

- Support for [mergeWhen](https://laravel.com/docs/12.x/eloquent-resources#merging-conditional-attributes) helper method. In this case the property should marked conditionally undefined
- Support for [whenLoaded](https://laravel.com/docs/12.x/eloquent-resources#conditional-relationships) helper method. In this case the property should marked conditionally undefined
- Support for [when](https://laravel.com/docs/12.x/eloquent-resources#conditional-attributes) helper method. In this case the property should marked conditionally undefined